### PR TITLE
1.2.0

### DIFF
--- a/src/Code/Code.cpp
+++ b/src/Code/Code.cpp
@@ -96,6 +96,12 @@ void Code::write(uint32_t address, byte *Code, uint8_t byteNumber)
       EEPROM.update((address + n), Code[n]);
 #endif
     }
+#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
+    if (!EEPROM.commit())
+    {
+      printDebug("ERROR: EEPROM commit failed!");
+    }
+#endif
   }
   else
   {

--- a/src/RFIDtoEEPROM/RFIDtoEEPROM.cpp
+++ b/src/RFIDtoEEPROM/RFIDtoEEPROM.cpp
@@ -20,8 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#if !defined(ARDUINO_ARCH_RP2040)
-
 #include <RFIDtoEEPROM.h>
 
 /**
@@ -34,7 +32,7 @@ RFIDtoEEPROM::RFIDtoEEPROM(uint8_t byteNumber) : Card(byteNumber)
   _local = true;
 }
 
-#if defined(ESP32) || defined(ESP8266)
+#if defined(ESP32) || defined(ESP8266) || defined(ARDUINO_ARCH_RP2040)
 
 #include <EEPROM.h>
 
@@ -49,6 +47,4 @@ void RFIDtoEEPROM::begin(uint32_t eepromSize)
   _maxCards = min(((EEPROM.length() - 1) / _byteNumber), 255);
 }
 
-#endif // ESP32 || ESP8266
-
-#endif // !ARDUINO_ARCH_RP2040
+#endif // ESP32 || ESP8266 || ARDUINO_ARCH_RP2040

--- a/src/RFIDtoEEPROM/RFIDtoEEPROM.h
+++ b/src/RFIDtoEEPROM/RFIDtoEEPROM.h
@@ -58,19 +58,15 @@ enum twiClockFreq_t
   TWICLOCK400KHZ = 400000
 };
 
-#if !defined(ARDUINO_ARCH_RP2040)
-
 class RFIDtoEEPROM : public Card
 {
   public:
     RFIDtoEEPROM(uint8_t byteNumber = 4);
 
-    #if defined(ESP32) || defined(ESP8266)
+#if defined(ESP32) || defined(ESP8266) || defined(ARDUINO_ARCH_RP2040)
     void begin(uint32_t eepromSize);
-    #endif
-};
-
 #endif
+};
 
 class RFIDtoEEPROM_I2C : public Card
 {


### PR DESCRIPTION
## Added
- Support for using the Raspberry Pico internal EEPROM.

## Fixed
- RAM write to flash memory missing.

**This pull request will remain pending until the raspberry pi platform validates Earlephilhower core support.**

You can already use this new feature by inserting the following in your `platformio.ini` file:
```ini
[env:pico]
platform = https://github.com/maxgerhardt/platform-raspberrypi.git
board = pico
framework = arduino
board_build.core = earlephilhower
lib_deps = https://github.com/GogoVega/RFIDtoEEPROM.git
```